### PR TITLE
[buffer] Destructor waits until all buffered tasks finish

### DIFF
--- a/include/hipipe/core/stream/buffer.hpp
+++ b/include/hipipe/core/stream/buffer.hpp
@@ -100,6 +100,13 @@ private:
             pop_buffer();
             fill_buffer();
         }
+
+        ~cursor()
+        {
+            for (auto& future : buffer_) {
+                if (future.valid()) future.wait();
+            }
+        }
     };  // class buffer_view
 
     cursor begin_cursor()


### PR DESCRIPTION
This should fix the SEGFAULT on premature finish of stream iteration.